### PR TITLE
Replace atrribute with variable and other updates

### DIFF
--- a/pep-0526.txt
+++ b/pep-0526.txt
@@ -1,5 +1,5 @@
 PEP: 526
-Title: Syntax for Variable and Attribute Annotations
+Title: Syntax for Variable Annotations
 Version: $Revision$
 Last-Modified: $Date$
 Author: Ryan Gonzalez <rymg19@gmail.com>, Philip House <phouse512@gmail.com>, Ivan Levkivskyi <levkivskyi@gmail.com>, Lisa Roach <lisaroach14@gmail.com>, Guido van Rossum <guido@python.org>
@@ -38,11 +38,12 @@ type comments to annotate variables::
   captain = ...  # type: str
 
   class Starship:
-      # 'stats' is a class attribute
+      # 'stats' is a class variable
       stats = {}  # type: Dict[str, int]
 
 This PEP aims at adding syntax to Python for annotating the types of variables
-and attributes, instead of expressing them through comments::
+(including non-method attributes), instead of expressing them through
+comments::
 
   primes: List[int] = []
 
@@ -60,7 +61,7 @@ expressed through comments has some downsides:
 
 - Text editors often highlight comments differently from type annotations.
 
-- There's no way to annotate the type of an undefined variable; you need to
+- There's no way to annotate the type of an undefined variable; one needs to
   initialize it to ``None`` (e.g. ``a = None # type: int``).
 
 - Variables annotated in a conditional branch are difficult to read::
@@ -119,8 +120,8 @@ party type checker::
 Below we specify the semantics of type annotations for type checkers
 in different contexts and their runtime effects.
 
-Variable Annotations
-********************
+Global and local variable annotations
+*************************************
 
 The types of locals and globals can be annotated as follows::
 
@@ -190,14 +191,15 @@ culprit, is accepted by the Python interpreter without questioning it
 -- but the subsequent type annotation expects it to be a
 ``MutableMapping`` and will fail.)
 
+.. _classvar
 
-Attribute annotations
-*********************
+Class and instance variable annotations
+***************************************
 
-Type annotations can also be used to annotate attributes
-in class bodies. In particular, the value-less notation ``a: int`` allows us
-to annotate instance variables that should be initialized in ``__init__``
-or ``__new__``. The proposed syntax is as follows::
+Type annotations can also be used to annotate class and instance variables
+in class bodies and methods. In particular, the value-less notation ``a: int``
+allows one to annotate instance variables that should be initialized
+in ``__init__`` or ``__new__``. The proposed syntax is as follows::
 
   class BasicStarship:
       captain: str = 'Picard'               # instance variable with default
@@ -205,7 +207,7 @@ or ``__new__``. The proposed syntax is as follows::
       stats: ClassVar[Dict[str, int]] = {}  # class variable
 
 Here ``ClassVar`` is a special class in typing module that indicates to
-static type checker that this attribute should not be set on class instances.
+static type checker that this variable should not be set on class instances.
 This could be illustrated with a more detailed example. In this class::
 
   class Starship:
@@ -246,7 +248,7 @@ For example, annotating the discussed class::
       enterprise_d.stats = {} # Flagged as error by a type checker
       Starship.stats = {} # This is OK
 
-As a matter of convenience, instance attributes can be annotated in
+As a matter of convenience, instance variables can be annotated in
 ``__init__`` or other methods, rather than in class::
 
   from typing import Generic, TypeVar
@@ -304,22 +306,24 @@ unpacking::
       ...
 
 
-Changes to standard library and documentation
+Changes to Standard Library and Documentation
 =============================================
 
 - A new covariant type ``ClassVar[T_co]`` is added to the ``typing``
   module. It accepts only a single argument that should be a valid type,
   and is used to annotate class variables that should no be set on class
   instances. This restriction is ensured by static checkers,
-  but not at runtime. See Attribute Annotations for examples
-  and explanations for the usage of ``ClassVar``, and see the Rejected
-  Proposals section for more information on the reasoning behind ``ClassVar``.
+  but not at runtime. See
+  :ref:`Class and instance variable annotations <classvar>` section for
+  examples and explanations for the usage of ``ClassVar``, and see
+  :ref:`Rejected Proposals <rejected>` section for more information on
+  the reasoning behind ``ClassVar``.
 
 - Function ``get_type_hints`` in the ``typing`` module will be extended,
   so that one can retrieve type annotations at runtime from modules
   and classes in addition to functions.
-  Annotations are returned as a dictionary mapping from variable, arguments,
-  or attributes to their type hints with forward references evaluated.
+  Annotations are returned as a dictionary mapping from variable or arguments
+  to their type hints with forward references evaluated.
   For classes it returns a mapping (perhaps ``collections.ChainMap``)
   constructed from annotations in method resolution order.
 
@@ -330,7 +334,7 @@ Changes to standard library and documentation
   separately from the standard library.
 
 
-Runtime effects of type annotations
+Runtime Effects of Type Annotations
 ===================================
 
 Annotating a local variable will cause
@@ -345,7 +349,7 @@ evaluated::
 
   x: NonexistentName  # Error!
   class X:
-      attr: NonexistentName  # Error!
+      var: NonexistentName  # Error!
 
 In addition, at the module or class level, if the item being annotated is a
 simple name, then it and the annotation will be stored in the
@@ -409,9 +413,10 @@ These stored annotations might be used for other purposes,
 but with this PEP we explicitly recommend type hinting as the
 preferred use of annotations.
 
+.. _rejected
 
-Rejected proposals and things left out for now
-==============================================
+Rejected/Postponed Proposals
+============================
 
 - **Should we introduce variable annotations at all?**
   Variable annotations have *already* been around for almost two years
@@ -488,11 +493,11 @@ Rejected proposals and things left out for now
   would needed to be checked for everywhere in the code. Therefore,
   Guido just said plain "No" to this.
 
-- **Add also** ``InstanceAttr`` **to the typing module:**
+- **Add also** ``InstanceVar`` **to the typing module:**
   This is redundant because instance variables are way more common than
   class variables. The more common usage deserves to be the default.
 
-- **Allow instance attribute annotations only in methods:**
+- **Allow instance variable annotations only in methods:**
   The problem is that many ``__init__`` methods do a lot of things besides
   initializing instance variables, and it would be harder (for a human)
   to find all the instance variable declarations.
@@ -522,7 +527,7 @@ Rejected proposals and things left out for now
   are always evaluated. Although this might be reconsidered in future,
   it was decided in PEP 484 that this would have to be a separate PEP.
 
-- **Declare attribute types in class docstring:**
+- **Declare variable types in class docstring:**
   Many projects already use various docstring conventions, often without
   much consistency and generally without conforming to the PEP 484 annotation
   syntax yet. Also this would require a special sophisticated parser.

--- a/pep-0526.txt
+++ b/pep-0526.txt
@@ -89,7 +89,10 @@ expressed through comments has some downsides:
   which is inelegant, to say the least.
 
 The majority of these issues can be alleviated by making the syntax
-a core part of the language.
+a core part of the language. Moreover, having a dedicated annotation syntax
+for class and instance variables (in addition to method annotations) will
+pave the way to static duck-typing as a complement to nominal typing defined
+by PEP 484.
 
 Non-goals
 *********
@@ -108,8 +111,8 @@ easy way to specify the structured type metadata for third party tools.
 Specification
 =============
 
-Type annotation can be added to an assignment statement or to a simple
-name indicating the desired type of the annotation target to a third
+Type annotation can be added to an assignment statement or to a single
+expression indicating the desired type of the annotation target to a third
 party type checker::
 
   my_var: int
@@ -160,7 +163,7 @@ it a local::
   def f():
       a: int
       print(a)  # raises UnboundLocalError
-      # Commenting out the ``a: int`` makes it a NameError.
+      # Commenting out the a: int makes it a NameError.
 
 as if the code were::
 
@@ -175,23 +178,7 @@ by a different type::
   a: int
   a: str  # Static type checker will warn about this.
 
-``__annotations__`` is writable, so this is permitted::
-
-  __annotations__['s'] = str
-
-But attempting to update ``__annotations__`` to something other than a dict
-may result in a TypeError::
-
-  class C:
-      __annotations__ = 42
-      x: int = 5  # raises TypeError
-
-(Note that the assignment to ``__annotations__``, which is the
-culprit, is accepted by the Python interpreter without questioning it
--- but the subsequent type annotation expects it to be a
-``MutableMapping`` and will fail.)
-
-.. _classvar
+.. _classvar:
 
 Class and instance variable annotations
 ***************************************
@@ -260,6 +247,7 @@ As a matter of convenience, instance variables can be annotated in
 
 Annotating expressions
 **********************
+
 The target of the annotation can be any valid single assignment target::
 
   class Cls:
@@ -267,14 +255,17 @@ The target of the annotation can be any valid single assignment target::
 
   c = Cls()
   c.x: int = 0  # Annotates c.x with int.
-  c.y: int  # Annotates c.y with int.
+  c.y: int      # Annotates c.y with int.
 
   d = {}
   d['a']: int = 0  # Annotates d['a'] with int.
-  d['b']: int  # Annotates d['b'] with int.
+  d['b']: int      # Annotates d['b'] with int.
 
-  (x): int  # Annotates x with int.
-  (y): int = 0  # Annotates y with int.
+Note that even a parenthesized name considered an expression,
+not a simple name::
+
+  (x): int      # Annotates x with int, (x) treated as expression by compiler.
+  (y): int = 0  # Same situation here.
 
 Where annotations aren't allowed
 ********************************
@@ -314,9 +305,8 @@ Changes to Standard Library and Documentation
   and is used to annotate class variables that should no be set on class
   instances. This restriction is ensured by static checkers,
   but not at runtime. See
-  :ref:`Class and instance variable annotations <classvar>` section for
-  examples and explanations for the usage of ``ClassVar``, and see
-  :ref:`Rejected Proposals <rejected>` section for more information on
+  :ref:`classvar` section for examples and explanations for the usage of
+  ``ClassVar``, and see :ref:`rejected` section for more information on
   the reasoning behind ``ClassVar``.
 
 - Function ``get_type_hints`` in the ``typing`` module will be extended,
@@ -352,7 +342,7 @@ evaluated::
       var: NonexistentName  # Error!
 
 In addition, at the module or class level, if the item being annotated is a
-simple name, then it and the annotation will be stored in the
+*simple name*, then it and the annotation will be stored in the
 ``__annotations__`` attribute of that module or class as a dictionary mapping
 from names to evaluated annotations. Here is an example::
 
@@ -363,6 +353,22 @@ from names to evaluated annotations. Here is an example::
 
   print(__annotations__)
   # prints: {'players': typing.Dict[str, __main__.Player]}
+
+``__annotations__`` is writable, so this is permitted::
+
+  __annotations__['s'] = str
+
+But attempting to update ``__annotations__`` to something other than a dict
+may result in a TypeError::
+
+  class C:
+      __annotations__ = 42
+      x: int = 5  # raises TypeError
+
+(Note that the assignment to ``__annotations__``, which is the
+culprit, is accepted by the Python interpreter without questioning it
+-- but the subsequent type annotation expects it to be a
+``MutableMapping`` and will fail.)
 
 The recommended way of getting annotations at runtime is by using
 ``typing.get_type_hints`` function; as with all dunder attributes,
@@ -413,7 +419,7 @@ These stored annotations might be used for other purposes,
 but with this PEP we explicitly recommend type hinting as the
 preferred use of annotations.
 
-.. _rejected
+.. _rejected:
 
 Rejected/Postponed Proposals
 ============================

--- a/pep-0526.txt
+++ b/pep-0526.txt
@@ -194,7 +194,7 @@ in ``__init__`` or ``__new__``. The proposed syntax is as follows::
       stats: ClassVar[Dict[str, int]] = {}  # class variable
 
 Here ``ClassVar`` is a special class in typing module that indicates to
-static type checker that this variable should not be set on class instances.
+static type checker that this variable should not be set on instances.
 This could be illustrated with a more detailed example. In this class::
 
   class Starship:
@@ -217,7 +217,7 @@ is truly a class variable -- it is intended to be shared by all instances.
 Since both variables happen to be initialized at the class level, it is
 useful to distinguish them by marking class variables as annotated with
 types wrapped in ``ClassVar[...]``. In such way type checker will prevent
-accidental assignments to attributes with a same name on class instances.
+accidental assignments to attributes with a same name on instances.
 For example, annotating the discussed class::
 
   class Starship:
@@ -304,9 +304,9 @@ Changes to Standard Library and Documentation
   module. It accepts only a single argument that should be a valid type,
   and is used to annotate class variables that should no be set on class
   instances. This restriction is ensured by static checkers,
-  but not at runtime. See
+  but not at runtime. See the
   :ref:`classvar` section for examples and explanations for the usage of
-  ``ClassVar``, and see :ref:`rejected` section for more information on
+  ``ClassVar``, and see the :ref:`rejected` section for more information on
   the reasoning behind ``ClassVar``.
 
 - Function ``get_type_hints`` in the ``typing`` module will be extended,


### PR DESCRIPTION
In this PR:
- Attributes replaced with variables almost everywhere.
- Formatting changes: internal refs, consistent capitalization in section titles (CapWords for sections, Normal for subsections), and some small changes.
- Moved the paragraph about mutability of `__annotations__` to the section runtime effects.
- Added possible future support for duck-typing (via Protocols as discussed in https://github.com/python/typing/issues/11) as one more argument in favor of the PEP.

Attn: @kirbyfan64 @phouse512 @gvanrossum @lisroach
